### PR TITLE
Add plugins folder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ impl std::error::Error for Error {
 #[must_use]
 pub struct RobloxStudio {
     root: PathBuf,
+    plugins: PathBuf,
 }
 
 impl RobloxStudio {
@@ -56,11 +57,16 @@ impl RobloxStudio {
 
         let content_folder_path = PathBuf::from(content_folder_value);
 
+        let root = content_folder_path.parent()
+            .ok_or(Error::MalformedRegistry)?;
+
+        let plugins = root.parent()
+            .ok_or(Error::MalformedRegistry)?.parent()
+            .ok_or(Error::MalformedRegistry)?.join("Plugins");
+
         Ok(RobloxStudio {
-            root: content_folder_path
-                .parent()
-                .ok_or(Error::MalformedRegistry)?
-                .to_owned(),
+            root: root.to_owned(),
+            plugins: plugins.to_owned(),
         })
     }
 
@@ -86,5 +92,11 @@ impl RobloxStudio {
     #[inline]
     pub fn built_in_plugins_path(&self) -> PathBuf {
         self.root.join("BuiltInPlugins")
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn plugins_path(&self) -> PathBuf {
+        self.plugins.to_owned()
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,6 +13,11 @@ fn test_windows() {
         .contains("BuiltInPlugins"));
 
     assert!(studio
+        .plugins_path()
+        .to_string_lossy()
+        .contains("Plugins"));
+
+    assert!(studio
         .exe_path()
         .to_string_lossy()
         .contains("RobloxStudioBeta.exe"));


### PR DESCRIPTION
Closes #3 

On windows, the folder for plugins is located above the root used here. I decided to add a new field on the struct, because on a mac it's located under `Documents/Roblox`.