### PR TITLE
Remove 'use dirs', which is not needed for crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use dirs;
-
 #[cfg(target_os = "windows")]
 use winreg::RegKey;
 


### PR DESCRIPTION
Small change!