### PR TITLE
Add support for getting content path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ impl std::error::Error for Error {
 #[derive(Debug)]
 #[must_use]
 pub struct RobloxStudio {
+    content: PathBuf,
     application: PathBuf,
     built_in_plugins: PathBuf,
     plugins: PathBuf,
@@ -67,16 +68,22 @@ impl RobloxStudio {
 
         let root = content_folder_path
             .parent()
-            .ok_or(Error::MalformedRegistry)?;
+            .ok_or(Error::MalformedRegistry)?
+            .to_path_buf();
 
         let user_dir = dirs::home_dir().ok_or(Error::PluginsDirectoryNotFound)?;
-        let plugin_dir = user_dir.join("AppData").join("Local").join("Roblox").join("Plugins");
+        let plugin_dir = user_dir
+            .join("AppData")
+            .join("Local")
+            .join("Roblox")
+            .join("Plugins");
 
         Ok(RobloxStudio {
+            content: content_folder_path,
             application: root.join("RobloxStudioBeta.exe"),
             built_in_plugins: root.join("BuiltInPlugins"),
             plugins: plugin_dir,
-            root: root.to_path_buf(),
+            root,
         })
     }
 
@@ -88,8 +95,10 @@ impl RobloxStudio {
         let built_in_plugins = contents.join("Resources").join("BuiltInPlugins");
         let documents = dirs::document_dir().ok_or(Error::DocumentsDirectoryNotFound)?;
         let plugins = documents.join("Roblox").join("Plugins");
+        let content = contents.join("Resources").join("content");
 
         Ok(RobloxStudio {
+            content,
             application,
             built_in_plugins,
             plugins,
@@ -118,6 +127,12 @@ impl RobloxStudio {
     #[inline]
     pub fn application_path(&self) -> &Path {
         &self.application
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn content_path(&self) -> &Path {
+        &self.content
     }
 
     #[deprecated(since = "0.2.0", note = "Please use application_path instead.")]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,7 @@
 #![allow(deprecated)]
 
+use std::fs;
+
 use roblox_install::RobloxStudio;
 
 #[cfg(target_os = "windows")]
@@ -20,6 +22,11 @@ fn test_windows() {
         .application_path()
         .to_string_lossy()
         .contains("RobloxStudioBeta.exe"));
+
+    let content = studio.content_path();
+    let meta = fs::metadata(&content).unwrap();
+    assert!(meta.is_dir());
+    assert!(content.to_string_lossy().contains("content"));
 }
 
 #[cfg(target_os = "macos")]
@@ -43,4 +50,9 @@ fn test_macos() {
         .application_path()
         .to_string_lossy()
         .contains("RobloxStudio"));
+
+    let content = studio.content_path();
+    let meta = fs::metadata(&content).unwrap();
+    assert!(meta.is_dir());
+    assert!(content.to_string_lossy().contains("content"));
 }


### PR DESCRIPTION
Closes #7.

Introduces a new method, `RobloxStudio::content_path`, that points to the install's `content` folder. Because we base everything off of the path on Windows, it was easy to introduce.

I wrote a more robust test for this for both Windows and MacOS than the other fields, but have only tested it on Windows since I don't have access to a MacOS machine. CI would be awesome!