### PR TITLE
allow installation from a environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # roblox-install Changelog
 
+## Unreleased
+
+* Added option to install from an environment variable [(#26)](https://github.com/Kampfkarren/roblox-install/issues/26)
+
 ## 0.3.0
 * Added `RobloxStudio::content_path`, returning the path to the `content` folder.
 


### PR DESCRIPTION
Hey 👋 

I have this issue on my fork of tarmac: https://github.com/jeparlefrancais/tarmac/issues/4

And since there was an issue opened in this repo, I went ahead and put something together. I don't have a MacOS to test the crate and I don't have WSL setup either, I'll ask around if I can find people to test it out.

The `locate_from_windows_directory` function is a little more complex, because instead of having to manually update the path to be exactly the directory of the current version, you can provide the main `Roblox` directory (under `AppData/Local`) and it will walk the directories in `Versions` until it finds the one with a `RobloxStudioBeta.exe`.

Close #26 