### PR TITLE
Add documentation to functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 const ROBLOX_STUDIO_PATH_VARIABLE: &'static str = "ROBLOX_STUDIO_PATH";
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     DocumentsDirectoryNotFound,
     MalformedRegistry,
@@ -76,6 +77,14 @@ pub struct RobloxStudio {
 }
 
 impl RobloxStudio {
+    /// Attempts to find a Roblox Studio installation. It will start by looking up
+    /// into the environment variable `ROBLOX_STUDIO_PATH`. If the variable is not
+    /// defined, it will find the usual installation on Windows and MacOS.
+    ///
+    /// On Windows (or WSL), the environment variable can point to a specific version (where
+    /// the `RobloxStudioBeta.exe` file and `content` directory are located) or it
+    /// can also point to the Roblox directory in AppData (`$APPDATA\Local\Roblox`)
+    /// and it will find the latest version by itself.
     pub fn locate() -> Result<RobloxStudio> {
         Self::locate_from_env()
             .unwrap_or_else(|| Self::locate_target_specific())
@@ -221,12 +230,14 @@ impl RobloxStudio {
 
     #[must_use]
     #[inline]
+    /// Path to the Roblox Studio executable
     pub fn application_path(&self) -> &Path {
         &self.application
     }
 
     #[must_use]
     #[inline]
+    /// Path to the content directory
     pub fn content_path(&self) -> &Path {
         &self.content
     }
@@ -240,12 +251,15 @@ impl RobloxStudio {
 
     #[must_use]
     #[inline]
+    /// Path to built-in plugins directory
     pub fn built_in_plugins_path(&self) -> &Path {
         &self.built_in_plugins
     }
 
     #[must_use]
     #[inline]
+    /// Path to the user's plugin directory. This directory may NOT exist if the Roblox Studio
+    /// user has never opened it from Roblox Studio `Plugins Folder` button.
     pub fn plugins_path(&self) -> &Path {
         &self.plugins
     }


### PR DESCRIPTION
I added some docs on functions. I did not add any on the deprecated ones, I assume you want to remove them for version 1.x?

I was not inspired for the error and RobloxStudio struct themselves, if you want to go ahead and push stuff on the branch before merging feel free to do it 🙂 

And I added the non_exhaustive attribute, so #25 should be good to go.

Closes #25 